### PR TITLE
这样不会导致极光服务器500

### DIFF
--- a/push/notification.go
+++ b/push/notification.go
@@ -8,10 +8,10 @@ import (
 
 // “通知”对象，是一条推送的实体内容对象之一（另一个是“消息”）
 type Notification struct {
-	Alert    string                `json:"alert"`
-	Android  *AndroidNotification  `json:"android"`
-	Ios      *IosNotification      `json:"ios"`
-	Winphone *WinphoneNotification `json:"winphone"`
+	Alert    string                `json:"alert,omitempty"`
+	Android  *AndroidNotification  `json:"android,omitempty"`
+	Ios      *IosNotification      `json:"ios,omitempty"`
+	Winphone *WinphoneNotification `json:"winphone,omitempty"`
 }
 
 func NewNotification(alert string) *Notification {


### PR DESCRIPTION
在我的使用过程中发现了一个问题，我这边为了不判断register id对应的平台，多个混平台的register id可以批量推送，所以每次推送的时候platform 选择的是all， 然后android平台统一都是推送message，所以android不会有notification，之前的代码会导致生成的json，android notification对应的value是null，导致极光服务器500， 所以添加了这么一个patch。

最后，感谢你的go sdk！
