### PR TITLE
message content不应该判空

### DIFF
--- a/push/message.go
+++ b/push/message.go
@@ -1,7 +1,5 @@
 package push
 
-import "github.com/DeanThompson/jpush-api-go-client/common"
-
 // 应用内消息。或者称作：自定义消息，透传消息。
 // 此部分内容不会展示到通知栏上，JPush SDK 收到消息内容后透传给 App。
 // 收到消息后 App 需要自行处理。
@@ -17,9 +15,6 @@ func NewMessage(content string) *Message {
 }
 
 func (m *Message) Validate() error {
-	if m.Content == "" {
-		return common.ErrMessageContentMissing
-	}
 
 	return nil
 }


### PR DESCRIPTION
有些推送场景就是推空字符串的content（“”）， 只是在extras里推送相关信息
